### PR TITLE
Fixed issue in com.github.nkzawa.engineio.client.Socket$7.call (Socke…

### DIFF
--- a/src/main/java/com/github/nkzawa/socketio/client/Socket.java
+++ b/src/main/java/com/github/nkzawa/socketio/client/Socket.java
@@ -329,7 +329,7 @@ public class Socket extends Emitter {
                 EventThread.exec(new Runnable() {
                     @Override
                     public void run() {
-                        if (sent[0]) return;
+                        if (sent == null || sent[0]) return;
                         sent[0] = true;
                         logger.fine(String.format("sending ack %s", args.length != 0 ? args : null));
 


### PR DESCRIPTION
…t.java:333), array is null

Crashlytics gives us this stacktrace:

Fatal Exception: java.lang.NullPointerException
Attempt to invoke virtual method 'com.github.do.if.do com.github.do.for.do.finally.b(java.lang.String, com.github.do.if.if)' on a null object reference
 raw
com.github.nkzawa.engineio.client.Socket$7.call (Socket.java:333)
com.github.nkzawa.emitter.Emitter$OnceListener.call (Emitter.java:164)
com.github.nkzawa.emitter.Emitter.emit (Emitter.java:117)
com.github.nkzawa.engineio.client.Transport.onOpen (Transport.java:112)
com.github.nkzawa.engineio.client.transports.WebSocket.access$002 (WebSocket.java:29)
com.github.nkzawa.engineio.client.transports.WebSocket$1$1.run (WebSocket.java:71)
com.github.nkzawa.thread.EventThread$2.run (EventThread.java:75)
java.util.concurrent.ThreadPoolExecutor.runWorker (ThreadPoolExecutor.java:1112)
java.lang.Thread.run (Thread.java:818)
